### PR TITLE
chore: use conservative generation settings

### DIFF
--- a/evaluation/eval_config.yaml
+++ b/evaluation/eval_config.yaml
@@ -17,12 +17,12 @@ model_parameters:
     subfolder: null
     generation_parameters:
       presence_penalty: 0.0
-      repetition_penalty: 1.0
+      repetition_penalty: 1.1
       frequency_penalty: 0.0
-      temperature: 1.0
-      top_k: 50
+      temperature: 0.4
+      top_k: 40
       min_p: 0.0
-      top_p: 1.0
+      top_p: 0.9
       seed: 42
       stop_tokens: null
       max_new_tokens: 1024


### PR DESCRIPTION
## Summary
- lower generation temperature to 0.4 and narrow sampling with top_p 0.9 and top_k 40
- slightly raise repetition penalty to 1.1 for more stable math answers

## Testing
- `python - <<'PY'
try:
    import yaml
    yaml.safe_load(open('evaluation/eval_config.yaml'))
    print('YAML OK')
except Exception as e:
    print('YAML check failed:', e)
PY`
- `pip install pyyaml` (failed: Could not find a version that satisfies the requirement pyyaml)


------
https://chatgpt.com/codex/tasks/task_e_6895fd445dc88329b80b04812e499a92